### PR TITLE
Fixed the triangle rendering issue for macOS

### DIFF
--- a/pyopengl/02 - triangle/finished/triangle.py
+++ b/pyopengl/02 - triangle/finished/triangle.py
@@ -43,7 +43,6 @@ class App:
             #refresh screen
             glClear(GL_COLOR_BUFFER_BIT)
 
-            glUseProgram(self.shader)
             glBindVertexArray(self.triangle.vao)
             glUseProgram(self.shader)
             glDrawArrays(GL_TRIANGLES, 0, self.triangle.vertex_count)

--- a/pyopengl/02 - triangle/finished/triangle.py
+++ b/pyopengl/02 - triangle/finished/triangle.py
@@ -15,9 +15,9 @@ class App:
         self.clock = pg.time.Clock()
         #initialise opengl
         glClearColor(0.1, 0.2, 0.2, 1)
+        self.triangle = Triangle()
         self.shader = self.createShader("shaders/vertex.txt", "shaders/fragment.txt")
         glUseProgram(self.shader)
-        self.triangle = Triangle(self.shader)
         self.mainLoop()
     
     def createShader(self, vertexFilepath, fragmentFilepath):
@@ -45,6 +45,7 @@ class App:
 
             glUseProgram(self.shader)
             glBindVertexArray(self.triangle.vao)
+            glUseProgram(self.shader)
             glDrawArrays(GL_TRIANGLES, 0, self.triangle.vertex_count)
 
             pg.display.flip()
@@ -61,9 +62,9 @@ class App:
 class Triangle:
 
 
-    def __init__(self, shader):
+    def __init__(self):
 
-        
+
         # x, y, z, r, g, b
         self.vertices = (
             -0.5, -0.5, 0.0, 1.0, 0.0, 0.0,


### PR DESCRIPTION
With the current version of triangle, for macOS, there is an issue trying the render the RGB triangle:
```
OpenGL.GL.shaders.ShaderValidationError: Validation failure (0): b'Validation Failed: No vertex array object bound.\n'
```

After checking it, the creation of shaders implies to get the VAO binded, which was not the case.
I simply moved the creation of the triangle **before** the shaders creation, and removed the `shaders` attribute from `Triangle` class as it is not used.

On macOS (m1 chip) the triangle example is now rendered (see screenshot below).
Based on my modifications, it should not be a problem for other OS / architectures.

<img width="654" alt="Capture d’écran 2022-07-23 à 17 30 38" src="https://user-images.githubusercontent.com/3605451/180611753-37d0f93a-7cc5-47bf-b6ea-f903fae8df04.png">



