### PR TITLE
Fix pyopengl finished examples

### DIFF
--- a/pyopengl/03 - textures/finished/textured_triangle.py
+++ b/pyopengl/03 - textures/finished/textured_triangle.py
@@ -19,11 +19,11 @@ class App:
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
+        self.triangle = Triangle()
         self.shader = self.createShader("shaders/vertex.txt", "shaders/fragment.txt")
         glUseProgram(self.shader)
         glUniform1i(glGetUniformLocation(self.shader, "imageTexture"), 0)
         self.wood_texture = Material("gfx/cat.png")
-        self.triangle = Triangle()
         self.mainLoop()
 
     def createShader(self, vertexFilepath, fragmentFilepath):

--- a/pyopengl/04 - transformations/finished/spinningCube.py
+++ b/pyopengl/04 - transformations/finished/spinningCube.py
@@ -24,13 +24,13 @@ class App:
         self.clock = pg.time.Clock()
         #initialise opengl
         glClearColor(0.1, 0.2, 0.2, 1)
+        self.cube_mesh = CubeMesh()
         self.shader = self.createShader("shaders/vertex.txt", "shaders/fragment.txt")
         glUseProgram(self.shader)
         glUniform1i(glGetUniformLocation(self.shader, "imageTexture"), 0)
         glEnable(GL_DEPTH_TEST)
 
         self.wood_texture = Material("gfx/wood.jpeg")
-        self.cube_mesh = CubeMesh()
 
         self.cube = Cube(
             position = [0,0,-3],

--- a/pyopengl/05 - loading Obj Models/finished/spinningCubeModel.py
+++ b/pyopengl/05 - loading Obj Models/finished/spinningCubeModel.py
@@ -24,13 +24,13 @@ class App:
         self.clock = pg.time.Clock()
         #initialise opengl
         glClearColor(0.1, 0.2, 0.2, 1)
+        self.cube_mesh = Mesh("models/cube.obj")
         self.shader = self.createShader("shaders/vertex.txt", "shaders/fragment.txt")
         glUseProgram(self.shader)
         glUniform1i(glGetUniformLocation(self.shader, "imageTexture"), 0)
         glEnable(GL_DEPTH_TEST)
 
         self.wood_texture = Material("gfx/wood.jpeg")
-        self.cube_mesh = Mesh("models/cube.obj")
 
         self.cube = Cube(
             position = [0,0,-3],


### PR DESCRIPTION
The error I reported [here](https://github.com/amengede/getIntoGameDev/pull/2) is reproduced in examples 3, 4, and 5.

I fixed them in making the same fix: moving the object [to render] creation code at higher level, in order to bind first the VAO and then creating the shaders. 